### PR TITLE
Remove thrilling slash form react-router basename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 
 root.render(
     <React.StrictMode>
-      <Router basename='/'>
+      <Router>
         <App />
       </Router>
     </React.StrictMode>


### PR DESCRIPTION
New Changes

- Remove the slash from the `basename` react-router property